### PR TITLE
fix(formatter): render fields as key values

### DIFF
--- a/logger_entry.go
+++ b/logger_entry.go
@@ -46,7 +46,7 @@ func newEntry(l *Logger) *entry {
 		ctxParser:  l.opt.ctxParser,
 	}
 
-	if l.opt.globalFields != nil && len(l.opt.globalFields) != 0 {
+	if len(l.opt.globalFields) != 0 {
 		copyFields(e.fields, l.opt.globalFields)
 	}
 

--- a/logger_formatter.go
+++ b/logger_formatter.go
@@ -96,14 +96,9 @@ func (f *TextFormatter) printFixedFields(b *bytes.Buffer, fixed *fixedField, pri
 // printFields append fields into buffer, sortField represents join
 // fields in order or not, the order is keys' lexicographical order.
 func (f *TextFormatter) printFields(b *bytes.Buffer, fields Fields) {
-	b.WriteString(" Fields{")
-	defer b.WriteString("}")
-
 	if !f.sortField {
-		n := 0
 		for key := range fields {
-			appendKeyValue(b, key, fields[key], n != 0, true)
-			n++
+			appendKeyValue(b, key, fields[key], true, false)
 		}
 		return
 	}
@@ -117,10 +112,8 @@ func (f *TextFormatter) printFields(b *bytes.Buffer, fields Fields) {
 	sort.Strings(keys)
 
 	// join the appended field by order of sorted keys.
-	n := 0
 	for _, key := range keys {
-		appendKeyValue(b, key, fields[key], n != 0, true)
-		n++
+		appendKeyValue(b, key, fields[key], true, false)
 	}
 }
 
@@ -135,13 +128,13 @@ func appendKeyValue(b *bytes.Buffer, key string, value interface{}, indent, with
 
 func appendValue(b *bytes.Buffer, value interface{}, withQuote bool) {
 	stringVal, ok := value.(string)
-	if ok {
-		if !withQuote {
-			b.WriteString(stringVal)
-			return
-		}
+	if !ok {
+		stringVal = fmt.Sprintf(_interfaceFormat, value)
+	}
+	if !withQuote {
+		b.WriteString(stringVal)
+		return
 	}
 
-	stringVal = fmt.Sprintf(_interfaceFormat, value)
-	b.WriteString(fmt.Sprintf("%q", stringVal))
+	fmt.Fprintf(b, "%q", stringVal)
 }

--- a/logger_formatter_test.go
+++ b/logger_formatter_test.go
@@ -63,7 +63,7 @@ func Test_appendValue(t *testing.T) {
 
 func Test_format(t *testing.T) {
 	formatter := newTextFormatter(
-		false, false, true, time.RFC3339)
+		false, true, true, time.RFC3339)
 	entry := entry{
 		logger:     nil,
 		out:        nil,
@@ -71,13 +71,13 @@ func Test_format(t *testing.T) {
 		lv:         0,
 		withCaller: false,
 		fixedField: &fixedField{Timestamp: 1747750112123},
-		fields:     Fields{"a": "a", "b": "b", "c": "c"},
+		fields:     Fields{"a": "a", "b": 200, "c": []string{"c", "d"}},
 		ctx:        nil,
 		ctxParser:  nil,
 	}
 	out, err := formatter.Format(&entry, "This is a test message")
 	assert.NoError(t, err)
-	assert.Equal(t, "[FTL] 2025-05-20T22:08:32+08:00 Fields{a=\"a\" b=\"b\" c=\"c\"} This is a test message\n", string(out))
+	assert.Equal(t, "[FTL] 2025-05-20T22:08:32+08:00 a=a b=200 c=[c d] This is a test message\n", string(out))
 }
 
 func Test_format_WithRawMillisecondTimestamp(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove Fields{...} wrapper from text formatter fields
- render field values without quotes
- simplify nil map length check

## Tests
- go test ./... -count=1